### PR TITLE
Artifacts based storage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ subprojects {
         testCompile "junit:junit:4.11"
         testCompile "org.mockito:mockito-all:1.10.19"
         testCompile "org.springframework:spring-test:${springVersion}"
+		testCompile "org.jetbrains.teamcity:tests-support:${teamcityVersion}"
         archives "mysql:mysql-connector-java:5.1.38"
         archives "com.mchange:c3p0:${c3p0Version}"
 	}

--- a/server/src/main/java/com/jpfeffer/teamcity/highlighter/service/ArtifactsBasedDataStoreService.java
+++ b/server/src/main/java/com/jpfeffer/teamcity/highlighter/service/ArtifactsBasedDataStoreService.java
@@ -1,0 +1,81 @@
+package com.jpfeffer.teamcity.highlighter.service;
+
+import com.jpfeffer.teamcity.highlighter.domain.HighlightData;
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.io.xml.CompactWriter;
+import jetbrains.buildServer.ArtifactsConstants;
+import jetbrains.buildServer.messages.XStreamHolder;
+import jetbrains.buildServer.serverSide.SBuild;
+import jetbrains.buildServer.util.FileUtil;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ * This storage stores HighlightData under the build hidden artifacts:
+ * .teamcity/pluginData/highlighter/
+ */
+public class ArtifactsBasedDataStoreService implements DataStoreService<HighlightData> {
+  private static final Logger LOG = Logger.getLogger(ArtifactsBasedDataStoreService.class.getName());
+
+  private final XStreamHolder myXStreamHolder = new XStreamHolder();
+  private final static String DATA_FILE_PATH = ArtifactsConstants.TEAMCITY_ARTIFACTS_DIR + "/pluginData/highlighter/highlighter.xml";
+
+  @Override
+  public void saveData(@NotNull SBuild sBuild, HighlightData data) {
+    List<HighlightData> currentData = loadData(sBuild);
+    boolean found = false;
+    for (int i=0; i<currentData.size(); i++) {
+      HighlightData cur = currentData.get(i);
+      if (cur.getKey().equals(data.getKey())) {
+        currentData.set(i, data);
+        found = true;
+        break;
+      }
+    }
+
+    if (!found) {
+      currentData.add(data);
+    }
+
+    final StringWriter writer = new StringWriter();
+    getXStream().marshal(currentData, new CompactWriter(writer));
+    String serialized = writer.toString();
+
+    final File filePath = getDataFilePath(sBuild);
+    try {
+      final File newFile = new File(filePath.getParent(), filePath.getName() + ".new"); // save as new to prevent existing data corruption if there is a lack of disk space
+      FileUtil.writeFile(newFile, serialized, "UTF-8");
+      FileUtil.rename(newFile, filePath);
+    } catch (Exception e) {
+      LOG.warning("Could not save highlighter plugin data under the build artifacts directory: " + filePath + ", error: " + e.toString());
+    }
+  }
+
+  private XStream getXStream() {
+    return myXStreamHolder.getXStream(getClass().getClassLoader());
+  }
+
+  @NotNull
+  private File getDataFilePath(@NotNull SBuild sBuild) {
+    return new File(sBuild.getArtifactsDirectory(), DATA_FILE_PATH);
+  }
+
+  @Override
+  public List<HighlightData> loadData(@NotNull SBuild sBuild) {
+    final File filePath = getDataFilePath(sBuild);
+    if (!filePath.isFile()) return new ArrayList<>();
+
+    try {
+      String data = FileUtil.readText(filePath, "UTF-8");
+      return (List<HighlightData>) getXStream().fromXML(data);
+    } catch (Exception e) {
+      LOG.warning("Could not load highlighter plugin data from the build artifacts directory: " + filePath + ", error: " + e.toString());
+    }
+    return new ArrayList<>();
+  }
+}

--- a/server/src/main/resources/META-INF/build-server-plugin-highlighter.xml
+++ b/server/src/main/resources/META-INF/build-server-plugin-highlighter.xml
@@ -16,6 +16,7 @@
     <bean id="teamcityCustomDataStoreService"
           class="com.jpfeffer.teamcity.highlighter.service.TeamCityCustomDataStoreService"/>
     <bean id="mySQLDataStoreService" class="com.jpfeffer.teamcity.highlighter.service.MySQLDataStoreService"/>
+    <bean id="artifactsBasedDataStoreService" class="com.jpfeffer.teamcity.highlighter.service.ArtifactsBasedDataStoreService"/>
 
     <bean id="mySQLDBAdapter" class="com.jpfeffer.teamcity.highlighter.service.adapter.MySQLDBAdapter">
         <property name="driver" value="${jdbc.mysql.driver}"/>

--- a/server/src/test/java/com/jpfeffer/teamcity/highlighter/service/ArtifactsBasedDataStoreServiceTest.java
+++ b/server/src/test/java/com/jpfeffer/teamcity/highlighter/service/ArtifactsBasedDataStoreServiceTest.java
@@ -1,0 +1,78 @@
+package com.jpfeffer.teamcity.highlighter.service;
+
+import com.jpfeffer.teamcity.highlighter.domain.Block;
+import com.jpfeffer.teamcity.highlighter.domain.HighlightData;
+import com.jpfeffer.teamcity.highlighter.domain.Level;
+import jetbrains.buildServer.TempFiles;
+import jetbrains.buildServer.serverSide.SBuild;
+import jetbrains.buildServer.serverSide.SBuildType;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import jetbrains.buildServer.util.FileUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.File;
+import java.util.Collection;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ArtifactsBasedDataStoreServiceTest {
+  private DataStoreService<HighlightData> dataStoreService;
+
+  @Mock
+  private SBuild sBuild;
+  @Mock
+  private SBuildType sBuildType;
+  @Mock
+  private HighlightData highlightData;
+
+  private TempFiles tempFiles;
+  private File buildArtifactsDir;
+
+  @Before
+  public void setUp() throws Exception {
+    tempFiles = new TempFiles();
+
+    dataStoreService = new ArtifactsBasedDataStoreService();
+    when(sBuild.getBuildId()).thenReturn(1234L);
+    when(sBuild.getBuildType()).thenReturn(sBuildType);
+    buildArtifactsDir = tempFiles.createTempDir();
+    when(sBuild.getArtifactsDirectory()).thenReturn(buildArtifactsDir);
+  }
+
+  @Test
+  public void testSaveData() throws Exception
+  {
+    when(highlightData.getKey()).thenReturn("Some title");
+    when(highlightData.getSingleValue()).thenReturn("Some text");
+    when(highlightData.getLevel()).thenReturn(Level.error);
+    when(highlightData.getBlock()).thenReturn(Block.collapsed);
+    dataStoreService.saveData(sBuild, highlightData);
+
+    File highlighterXml = new File(buildArtifactsDir, ArtifactsBasedDataStoreService.DATA_FILE_PATH);
+    assertTrue(highlighterXml.isFile());
+
+    final Collection<HighlightData> data = dataStoreService.loadData(sBuild);
+    assertEquals(1, data.size());
+    final HighlightData loadedData = data.iterator().next();
+    assertEquals("Some title", loadedData.getKey());
+    assertEquals("Some text", loadedData.getSingleValue());
+  }
+
+  @After
+  public void tearDown() {
+    tempFiles.cleanup();
+  }
+
+}


### PR DESCRIPTION
This patch creates a new data source for highlighter plugin data which is based on build artifacts. I'd propose to make it a default one, as existing two storages have significant downsides:
- custom data based store stores data of builds in build configuration custom data which was never intended to be used this way; current approach causes unlimited growth of build type data storage because data is never cleaned, which in turn causes significant performance problems: https://youtrack.jetbrains.com/issue/TW-56401
- MySQL based data store requires setup of a dedicated MySQL database just to keep this plugin data which looks like overkill

In fact, if data should be associated with build, then there is already convenient storage for this - build hidden artifacts. So I made a new data store which keeps data there. It does not cause performance issues, as well as memory usage problems. So I'd propose to make it a default one.
